### PR TITLE
Graceful shutdown on SIGINT

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -450,6 +450,7 @@ func main() {
 			signal.Notify(c, os.Kill)
 			_ = <-c // block
 			logging.Infof("Shutting down listener")
+			// this will exit the watcher loop, after which all listeners are killed, then finally the connection channel
 			close(updates)
 		}()
 		if *instanceSrc != "" {

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -443,6 +444,13 @@ func main() {
 		defer fuse.Close()
 	} else {
 		updates := make(chan string)
+		go func() {
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt)
+			_ = <-c // block
+			logging.Infof("Received SIGINT. Shutting down listener")
+			close(updates)
+		}()
 		if *instanceSrc != "" {
 			go func() {
 				for {

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -447,8 +447,9 @@ func main() {
 		go func() {
 			c := make(chan os.Signal, 1)
 			signal.Notify(c, os.Interrupt)
+			signal.Notify(c, os.Kill)
 			_ = <-c // block
-			logging.Infof("Received SIGINT. Shutting down listener")
+			logging.Infof("Shutting down listener")
 			close(updates)
 		}()
 		if *instanceSrc != "" {

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -114,6 +114,7 @@ func watchInstancesLoop(dir string, dst chan<- proxy.Conn, updates <-chan string
 		}
 	}
 
+	// dst is what callers of WatchInstances are reading, so closing it will invoke graceful shutdown
 	close(dst)
 }
 

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -113,6 +113,8 @@ func watchInstancesLoop(dir string, dst chan<- proxy.Conn, updates <-chan string
 			logging.Errorf("Error closing %q: %v", v.Addr(), err)
 		}
 	}
+
+	close(dst)
 }
 
 func remove(path string) {


### PR DESCRIPTION
* Closes the updates channel on receipt of `SIGINT`
* Closing updates triggers a close of all listeners
* Added close of new connects to end of `watchInstancesLoop`

https://bluecore.atlassian.net/browse/PROD-12017